### PR TITLE
Disable Google Analytics and FullStory in dev builds

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,4 +1,4 @@
-{{ if .Site.GoogleAnalytics }}
+{{ if and hugo.IsProduction .Site.GoogleAnalytics }}
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"></script>
 <script>

--- a/layouts/partials/fullstory.html
+++ b/layouts/partials/fullstory.html
@@ -1,3 +1,4 @@
+{{ if hugo.IsProduction }}
 <script>
     window['_fs_debug'] = false;
     window['_fs_host'] = 'fullstory.com';
@@ -15,3 +16,4 @@
         g.clearUserCookie=function(){};
     })(window,document,window['_fs_namespace'],'script','user');
 </script>
+{{ end }}


### PR DESCRIPTION
## What

Gate the **Google Analytics (GA4)** and **FullStory** tracking partials behind `hugo.IsProduction` so local `hugo serve` builds no longer send pageviews or session recordings to the production analytics properties.

- `layouts/partials/analytics.html` — GA loader now requires `hugo.IsProduction`
- `layouts/partials/fullstory.html` — FullStory snippet now wrapped in `hugo.IsProduction`

## Why

Previously these loaded whenever the relevant config was set, with no environment guard, so browsing the site locally sent hits to the real GA property (`G-4244ZMRC67`) and FullStory org. This pollutes analytics with developer traffic.

## Behavior

- **`hugo serve` (development):** no GA, no FullStory.
- **Netlify production build:** both unchanged / still active.

## Verification

- Dev server (`localhost:1313`): 0 GA loader refs, 0 FullStory refs.
- `hugo --environment production` build: GA and FullStory present as before.

## Notes (not changed here)

- Inline `onclick="gtag('event', …)"` handlers remain in the markup; they're inert in dev since the GA library isn't loaded (no events fire).
- The active chat widget is **Zendesk** (loads in all environments); the Crisp block in `scripts.html` is already commented out / dead. Can gate Zendesk and remove the dead Crisp `websiteId` in a follow-up if desired.