### PR TITLE
Add honeypot field to Formspree forms to prevent spam

### DIFF
--- a/layouts/partials/quote.html
+++ b/layouts/partials/quote.html
@@ -14,6 +14,12 @@
 
                     <input type="hidden" name="type" value="quote"/>
 
+                    <!-- Honeypot: hidden from users, bots fill it and Formspree discards the submission -->
+                    <div style="position:absolute;left:-9999px;" aria-hidden="true">
+                        <label for="quote-gotcha">Leave this field empty</label>
+                        <input type="text" name="_gotcha" id="quote-gotcha" tabindex="-1" autocomplete="off"/>
+                    </div>
+
                     <h4><i class="fa fa-user text-muted"></i> About You</h4>
                     <p class="text-muted text-small">Helps us understand who you are and how to reach you.</p>
                     <hr/>

--- a/layouts/partials/signup.html
+++ b/layouts/partials/signup.html
@@ -16,6 +16,12 @@
 
                     <input type="hidden" name="type" value="signup"/>
 
+                    <!-- Honeypot: hidden from users, bots fill it and Formspree discards the submission -->
+                    <div style="position:absolute;left:-9999px;" aria-hidden="true">
+                        <label for="signup-gotcha">Leave this field empty</label>
+                        <input type="text" name="_gotcha" id="signup-gotcha" tabindex="-1" autocomplete="off"/>
+                    </div>
+
                     <div class="row">
 
                         <div class="col-sm-6">

--- a/layouts/partials/tutorials.html
+++ b/layouts/partials/tutorials.html
@@ -93,6 +93,11 @@
                         </div>
                     </div>
                     <form class="tutorials-form" method="post" action="https://formspree.io/f/xadkvonm">
+                        <!-- Honeypot: hidden from users, bots fill it and Formspree discards the submission -->
+                        <div style="position:absolute;left:-9999px;" aria-hidden="true">
+                            <label for="tutorials-gotcha">Leave this field empty</label>
+                            <input type="text" name="_gotcha" id="tutorials-gotcha" tabindex="-1" autocomplete="off"/>
+                        </div>
                         <div class="row">
                             <div class="col-sm-12">
                                 <div class="form-group">

--- a/layouts/partials/users.html
+++ b/layouts/partials/users.html
@@ -79,6 +79,11 @@
                 <p class="text-muted">Tell us about how your organization uses OpenBoxes. We'd love to feature you on our implementations map.</p>
                 <form id="implementation-form" method="post" action="https://formspree.io/f/xreybadz">
                     <input type="hidden" name="type" value="implementation"/>
+                    <!-- Honeypot: hidden from users, bots fill it and Formspree discards the submission -->
+                    <div style="position:absolute;left:-9999px;" aria-hidden="true">
+                        <label for="impl-gotcha">Leave this field empty</label>
+                        <input type="text" name="_gotcha" id="impl-gotcha" tabindex="-1" autocomplete="off"/>
+                    </div>
                     <div class="row">
                         <div class="col-sm-6">
                             <div class="form-group">


### PR DESCRIPTION
## Summary
Adds a visually-hidden honeypot (`_gotcha`) field to all four Formspree-backed forms to cut down on bot spam submissions.

`_gotcha` is Formspree's built-in honeypot field name: real users never see or fill it, but bots tend to auto-fill every input, and Formspree silently discards any submission where it's populated. No server-side config or third-party scripts (e.g. reCAPTCHA) required.

## Forms updated
- `layouts/partials/quote.html` — quote request
- `layouts/partials/signup.html` — services signup
- `layouts/partials/tutorials.html` — tutorials email
- `layouts/partials/users.html` — implementation form

Each honeypot is wrapped in an off-screen container (`position:absolute; left:-9999px`) with `aria-hidden="true"`, and the input uses `tabindex="-1"` / `autocomplete="off"` so it's skipped by keyboard navigation, screen readers, and autofill.

## Testing
- Builds cleanly with the pinned Hugo 0.92.2.
- Confirmed `_gotcha` renders in `public/{quote,signup,tutorials,users}/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)